### PR TITLE
added meta description for search engines, and hrefs for some links

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <meta property="og:title" content="LibRedirect - privacy-friendly Redirector">
   <meta property="og:site_name" content="libredirect.github.io">
   <meta property="og:description" content="A web extension that redirects YouTube, Twitter, Instagram... requests to alternative privacy friendly frontends and backends">
+  <meta name="description" content="A web extension that redirects YouTube, Twitter, Instagram... requests to alternative privacy friendly frontends and backends">
   <title>LibRedirect</title>
 </head>
 
@@ -140,14 +141,14 @@
     </div>
     <hr>
     <h3 id="why_libredirect"><a href="#why_libredirect">Why LibRedirect?</a></h3>
-    <p>Normally you watch YouTube videos through <a>youtube.com</a>'s server. Problem is everything
+    <p>Normally you watch YouTube videos through <a href="https://www.youtube.com/">youtube.com</a>'s server. Problem is everything
       you watch is tied to your Google Account. Even if you didn't use an account, your IP address is still visible.
       Even if you used <a href="https://www.torproject.org/">Tor</a>, you still have <a href="https://en.wikipedia.org/wiki/JavaScript">JavaScript</a> enabled, a programming language that can get so
       much information about your browser and your system it's a little creepy. Just go to <a href="https://deviceinfo.me">deviceinfo.me</a> or <a href="https://www.amiunique.org">amiunique.org</a> and see
       how much information is available to know about you.<br></p>
     <p>So, why not disabling JavaScript? Great idea! Now YouTube is broken as it requires JavaScript to function
       ¯\_(ツ)_/¯</p>
-    <p>There's a way though to make a script that scraps data off of <a>youtube.com</a> and presents
+    <p>There's a way though to make a script that scraps data off of <a href="https://www.youtube.com/">youtube.com</a> and presents
       it in a nice simple webpage that doesn't require JavaScript. People have done this already! There's a project
       called <a href="https://github.com/iv-org/invidious">Invidious</a> that doesn't require JavaScript for you to
       watch YouTube videos, ex: <a href=https://yewtu.be/watch?v=dQw4w9WgXcQ>https://yewtu.be/watch?v=dQw4w9WgXcQ</a>


### PR DESCRIPTION
This PR adds `description` to be present alongside `og:description` as a meta tag since I found out the difference between the two that:
- `description` is used by search engines
- `og:description` is used by social media networks

I have also added `href` links for the `<a>youtube.com</a>` sections, as it is considered a good practice.