### PR TITLE
Update download_chromium.html to deliver Libredirect version 2.8.0. Fix OS steps enumeration.

### DIFF
--- a/download_chromium.html
+++ b/download_chromium.html
@@ -51,8 +51,8 @@
     <p>
       5. Right click on this <span class="yellow">.crx</span> file, and click <span class="yellow">Save Link
         As...</span> to save it:
-      <a href="https://github.com/libredirect/libredirect/releases/download/v2.5.4/libredirect-2.5.4.crx">
-        libredirect-2.5.4.crx
+      <a href="https://github.com/libredirect/browser_extension/releases/download/v2.8.0/libredirect-2.8.0.crx">
+        libredirect-2.8.0.crx
       </a>
     </p>
     <p>6. Go to <span class="yellow">Extension Manager</span> again, and drag and drop the <span
@@ -63,12 +63,12 @@
 
     <h3 id="mac"><a href="#mac">MacOS</a></h3>
     <p>1. Download the latest zip file <a
-        href="https://github.com/libredirect/libredirect/releases/download/v2.5.4/libredirect-2.5.4.zip">libredirect-2.5.4.zip</a>
+        href="https://github.com/libredirect/browser_extension/releases/download/v2.8.0/libredirect-2.8.0.zip">libredirect-2.8.0.zip</a>
     </p>
     <p>2. Unzip it with `Auto detect subfolder`</p>
     <p>3. Go to <span class="yellow">Extension Manager</span>, and enable <span class="yellow">developer mode</span></p>
     <p>5. Click <span class="yellow">Load unpacked</span>. Select and open <span
-        class="yellow">libredirect-2.5.4/src/</span></p>
+        class="yellow">libredirect-2.8.0/src/</span></p>
     <video
       src="https://media.githubusercontent.com/media/libredirect/libredirect.github.io/master/vids/install_chrome_load_unpacked.mp4"
       controls></video>
@@ -77,8 +77,8 @@
     <p>
       1. Right click on this <span class="yellow">.crx</span> file, and click <span class="yellow">Save Link
         As...</span> to save it:
-      <a href="https://github.com/libredirect/libredirect/releases/download/v2.5.4/libredirect-2.5.4.crx">
-        libredirect-2.5.4.crx
+      <a href="https://github.com/libredirect/browser_extension/releases/download/v2.8.0/libredirect-2.8.0.crx">
+        libredirect-2.8.0.crx
       </a>
     </p>
     <p>2. Go to <span class="yellow">Extension Manager</span>, and enable <span class="yellow">developer mode</span></p>

--- a/download_chromium.html
+++ b/download_chromium.html
@@ -39,7 +39,7 @@
     </h2>
     <h3 id="windows"><a href="#windows">Windows</a></h3>
     <p>1. Go to <span class="yellow">Extension Manager</span>, and enable <span class="yellow">developer mode</span></p>
-    <p>3. Run this registery file:
+    <p>2. Run this registery file:
       <a href="./chromium_reg/chrome.reg" download>chrome.reg</a> or
       <a href="./chromium_reg/brave.reg" download>brave.reg</a> or
       <a href="./chromium_reg/edge.reg" download>edge.reg</a> or
@@ -47,15 +47,15 @@
       <br>
       Note: Opera doesn't need a registery file file.
     </p>
-    <p>4. Restart your browser</p>
+    <p>3. Restart your browser</p>
     <p>
-      5. Right click on this <span class="yellow">.crx</span> file, and click <span class="yellow">Save Link
+      4. Right click on this <span class="yellow">.crx</span> file, and click <span class="yellow">Save Link
         As...</span> to save it:
       <a href="https://github.com/libredirect/browser_extension/releases/download/v2.8.0/libredirect-2.8.0.crx">
         libredirect-2.8.0.crx
       </a>
     </p>
-    <p>6. Go to <span class="yellow">Extension Manager</span> again, and drag and drop the <span
+    <p>5. Go to <span class="yellow">Extension Manager</span> again, and drag and drop the <span
         class="yellow">.crx</span> file</p>
     <video
       src="https://media.githubusercontent.com/media/libredirect/libredirect.github.io/master/vids/install_chromium.mp4"
@@ -67,7 +67,7 @@
     </p>
     <p>2. Unzip it with `Auto detect subfolder`</p>
     <p>3. Go to <span class="yellow">Extension Manager</span>, and enable <span class="yellow">developer mode</span></p>
-    <p>5. Click <span class="yellow">Load unpacked</span>. Select and open <span
+    <p>4. Click <span class="yellow">Load unpacked</span>. Select and open <span
         class="yellow">libredirect-2.8.0/src/</span></p>
     <video
       src="https://media.githubusercontent.com/media/libredirect/libredirect.github.io/master/vids/install_chrome_load_unpacked.mp4"
@@ -82,9 +82,9 @@
       </a>
     </p>
     <p>2. Go to <span class="yellow">Extension Manager</span>, and enable <span class="yellow">developer mode</span></p>
-    <p>4. Refresh the page</p>
+    <p>3. Refresh the page</p>
     <p>
-      5. Drag and drop the <span class="yellow">.crx</span> file
+      4. Drag and drop the <span class="yellow">.crx</span> file
     </p>
     </p>
 


### PR DESCRIPTION
The old version of download_chromium.html would offer to download the version 2.5.4 of Libredirect, now it offers version 2.8.0.

The old version OS install steps with a wrong enumeration, it would skip some numbers, this pr fixes those typos.