### PR TITLE
Add few more Android clients to the list

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -190,7 +190,7 @@
       <li>
         YouTube <span>&#8594;</span>
         <a href="https://libretube.dev/">LibreTube</a>,
-        <a href="https://github.com/lamarios/clipious"></a>,
+        <a href="https://github.com/lamarios/clipious">Clipious</a>,
         <a href="https://newpipe.net/">NewPipe</a>
       </li>
       <li>
@@ -199,7 +199,8 @@
       </li>
       <li>
         Translate <span>&#8594;</span>
-        <a href="https://github.com/you-apps/TranslateYou">TranslateYou</a>
+        <a href="https://github.com/you-apps/TranslateYou">TranslateYou</a>,
+        <a href="https://manerakai.github.io/simplytranslate_mobile/">SimplyTranslate Mobile</a>
       </li>
     </ul>
   </div>

--- a/faq.html
+++ b/faq.html
@@ -183,9 +183,15 @@
     <p>Rather than using LibRedirect, use these apps:</p>
     <ul class="clear">
       <li>
+        URL Manipulation <span>&#8594;</span>
+        <a href="https://github.com/TrianguloY/UrlChecker">URLCheck</a>,
+        <a href="https://github.com/1fexd/LinkSheet">LinkSheet</a>
+      </li>
+      <li>
         YouTube <span>&#8594;</span>
-        <a href="https://newpipe.net/">NewPipe</a>,
-        <a href="https://libretube.dev/">LibreTube</a>
+        <a href="https://libretube.dev/">LibreTube</a>,
+        <a href="https://github.com/lamarios/clipious"></a>,
+        <a href="https://newpipe.net/">NewPipe</a>
       </li>
       <li>
         Twitter <span>&#8594;</span>
@@ -193,7 +199,7 @@
       </li>
       <li>
         Translate <span>&#8594;</span>
-        <a href="https://manerakai.github.io/simplytranslate_mobile/">SimplyTranslate Mobile</a>
+        <a href="https://github.com/you-apps/TranslateYou">TranslateYou</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
- URLCheck ([Custom patterns](https://github.com/TrianguloY/UrlChecker/wiki/Custom-patterns))
- LinkSheet (Supports _Experimental_: LibRedirect integration, see [here](https://github.com/1fexd/libredirectkt))

These 2 are the active ones from the [list](https://github.com/offa/android-foss#-url-manipulation).
- Clipious (Invidious client)
- TranslateYou ([Multiple engines](https://github.com/you-apps/TranslateYou#supported-translation-engines) support)