### PR TITLE
Fix invalid/broken links, updated to libredirect.manerakai.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 - No external dependencies
 
 ## Mirror Repos
-[![Codeberg](./img/repos/codeberg.svg)](https://codeberg.org/LibRedirect/pages)&nbsp;&nbsp;[![GitHub](./img/repos/github.svg)](https://github.com/libredirect/libredirect.github.io)&nbsp;&nbsp;
+[![Codeberg](./img/repos/codeberg.svg)](https://codeberg.org/LibRedirect/website)&nbsp;&nbsp;[![GitHub](./img/repos/github.svg)](https://github.com/libredirect/website)&nbsp;&nbsp;
 

--- a/contact.html
+++ b/contact.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Contact</title>

--- a/docs.html
+++ b/docs.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Docs</title>
@@ -105,7 +105,7 @@
         Firefox Android</a></h3>
     <p>Go to Settings => Search => Default search engine => Add search engine:<br>
       <strong>Search engine name:</strong> LibRedirect<br>
-      <strong>Search string URL:</strong> http://libredirect.github.io/?q=%s
+      <strong>Search string URL:</strong> http://libredirect.manerakai.com/?q=%s
     </p>
     <br><br><br>
   </div>

--- a/donate.html
+++ b/donate.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Donate</title>

--- a/download.html
+++ b/download.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Download</title>

--- a/download_chromium.html
+++ b/download_chromium.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Download</title>

--- a/faq.html
+++ b/faq.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>FAQ</title>

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect - Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>LibRedirect</title>

--- a/libredirect.github.io.kdev4
+++ b/libredirect.github.io.kdev4
@@ -1,4 +1,0 @@
-[Project]
-CreatedFrom=
-Manager=KDevGenericManager
-Name=libredirect.github.io

--- a/mobile.html
+++ b/mobile.html
@@ -7,10 +7,10 @@
     <meta name="robots" content="index, follow">
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" type="image/x-icon" href="img/icon.svg">
-    <link rel="canonical" href="https://libredirect.github.io">
+    <link rel="canonical" href="https://libredirect.manerakai.com">
     <meta property="og:type" content="website">
     <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-    <meta property="og:site_name" content="libredirect.github.io">
+    <meta property="og:site_name" content="libredirect.manerakai.com">
     <meta property="og:description"
         content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
     <title>Mobile</title>

--- a/source_code.html
+++ b/source_code.html
@@ -7,10 +7,10 @@
   <meta name="robots" content="index, follow">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/x-icon" href="img/icon.svg">
-  <link rel="canonical" href="https://libredirect.github.io">
+  <link rel="canonical" href="https://libredirect.manerakai.com">
   <meta property="og:type" content="website">
   <meta property="og:title" content="LibRedirect – Privacy-friendly Redirector">
-  <meta property="og:site_name" content="libredirect.github.io">
+  <meta property="og:site_name" content="libredirect.manerakai.com">
   <meta property="og:description"
     content="A web extension that redirects YouTube, Twitter, Instagram, etc. requests to alternative privacy-friendly frontends">
   <title>Source Code</title>

--- a/widgets/head.html
+++ b/widgets/head.html
@@ -4,8 +4,8 @@
 <meta name="robots" content="index, follow"/>
 <link rel="stylesheet" href="css/style.css"/>
 <link rel="icon" type="image/x-icon" href="img/icon.svg"/>
-<link rel="canonical" href="https://libredirect.github.io"/>
+<link rel="canonical" href="https://libredirect.manerakai.com"/>
 <meta property="og:type" content="website"/>
 <meta property="og:title" content="LibRedirect - privacy-friendly Redirector"/>
-<meta property="og:site_name" content="libredirect.github.io"/>
+<meta property="og:site_name" content="libredirect.manerakai.com"/>
 <meta property="og:description" content="A web extension that redirects YouTube, Twitter, Instagram... requests to alternative privacy friendly frontends and backends"/>


### PR DESCRIPTION
# Point links to the new domain `libredirect.manerakai.com`.

* A lot of references were still pointing to the old domain (`libredirect.github.io`), those were updated.

These were correctly redirecting (but were updated anyway):
* github repository link to https://github.com/libredirect/website
* codeberg repository link to https://codeberg.org/LibRedirect/website

# Existing domain redirect

If you open https://libredirect.github.io you're greeted with this:
<img width="730" height="425" alt="Screenshot 2026-06-19 at 14 26 35" src="https://github.com/user-attachments/assets/0bc1f3ab-365f-43ef-bde9-8c6c88d490c6" />

If possible, (re)create the repository at https://github.com/libredirect/libredirect.github.io and put an index.html file there with this:

```
<!DOCTYPE html>
<html>
  <head>
    <title>Redirecting...</title>
    <link rel="canonical" href="https://libredirect.manerakai.com" />
    <meta charset="utf-8" />
    <meta http-equiv="refresh" content="0; url=https://libredirect.manerakai.com" />
  </head>
  <body>
    <p>Redirecting...</p>
  </body>
</html>
```

This should handle **most** lingering references to libredirect.github.io.

If you want to be thorough you can add one for each html file to redirect to the right one (there aren't that many 🙂).